### PR TITLE
Updated md provider to use new namings

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,6 @@
   "license": "MIT",
   "dependencies": {
     "angular": ">=1.2.*",
-    "showdown": "~0.3.1"
+    "showdown": "~1.0.0"
   }
 }

--- a/markdown.js
+++ b/markdown.js
@@ -8,7 +8,7 @@ angular.module('markdown', [])
         opts = newOpts;
       },
       $get: function () {
-        return new window.Showdown.converter(opts);
+        return new window.showdown.Converter(opts);
       }
     };
   }])


### PR DESCRIPTION
From the ShowdownJS changelog as of version 1.0.0:

> Breaking Changes
NAMESPACE: showdown's namespace changed.
To migrate your code you should update all references to Showdown with showdown.
Converter: converter reference changed from converter to Converter.
To migrate you should update all references to Showdown.converter with showdown.Converter